### PR TITLE
fix: change servlet headers type to string

### DIFF
--- a/arex-storage-model/pom.xml
+++ b/arex-storage-model/pom.xml
@@ -8,7 +8,7 @@
         <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <artifactId>arex-storage-model</artifactId>
     <dependencies>
         <dependency>

--- a/arex-storage-model/src/main/java/com/arextest/storage/model/mocker/MainEntry.java
+++ b/arex-storage-model/src/main/java/com/arextest/storage/model/mocker/MainEntry.java
@@ -65,10 +65,6 @@ public interface MainEntry extends MockItem {
         return "POST";
     }
 
-    default Map<String, String> getRequestHeaders() {
-        return null;
-    }
-
     default String getPath() {
         return null;
     }

--- a/arex-storage-model/src/main/java/com/arextest/storage/model/mocker/impl/ServletMocker.java
+++ b/arex-storage-model/src/main/java/com/arextest/storage/model/mocker/impl/ServletMocker.java
@@ -21,8 +21,8 @@ public class ServletMocker extends AbstractMocker implements MainEntry {
     private String method;
     private String path;
     private String pattern;
-    private Map<String, String> requestHeaders;
-    private Map<String, String> responseHeaders;
+    private String requestHeaders;
+    private String responseHeaders;
     @FieldCompression
     private String request;
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <spring.boot.version>1.5.9.RELEASE</spring.boot.version>
         <jmockit.version>1.49</jmockit.version>
         <lombok.version>1.18.2</lombok.version>
-        <arex.storage.model.version>1.0.0</arex.storage.model.version>
+        <arex.storage.model.version>1.0.1</arex.storage.model.version>
 
         <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
         <!-- single jacoco.exec file relative to root directory of the project -->


### PR DESCRIPTION
MongoDB uses the dot notation to access the elements of an array and to access the fields of an embedded document.

https://www.mongodb.com/docs/manual/core/document/#dot-notation