### PR TITLE
修复mongo编码问题

### DIFF
--- a/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/MongoDbUtils.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/MongoDbUtils.java
@@ -6,9 +6,19 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.mongodb4.MongoDb4DocumentObject;
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.Document;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
+
+import java.util.Map;
 
 /**
  * @author jmo
@@ -46,7 +56,47 @@ public final class MongoDbUtils {
         AREXMockerCodecProvider arexMockerCodecProvider = new AREXMockerCodecProvider();
         final CodecRegistry customPojo = CodecRegistries.fromProviders(arexMockerCodecProvider, PojoCodecProvider
                 .builder().automatic(true).build());
+        MongoDb4DocumentObjectCodecProvider mongoDb4DocumentObjectCodecProvider = new MongoDb4DocumentObjectCodecProvider();
         return CodecRegistries.fromRegistries(MongoClientSettings.getDefaultCodecRegistry(),
-                customPojo);
+                customPojo,CodecRegistries.fromProviders(mongoDb4DocumentObjectCodecProvider));
+    }
+
+
+    public static class MongoDb4DocumentObjectCodecProvider implements CodecProvider {
+        @Override
+        public <T> Codec<T> get(Class<T> clazz, CodecRegistry registry) {
+            if (MongoDb4DocumentObject.class.equals(clazz))
+                return (Codec<T>) new MongoDb4DocumentObjectCodec(registry);
+            return null;
+        }
+
+        private class MongoDb4DocumentObjectCodec implements Codec<MongoDb4DocumentObject> {
+
+            private final Codec<Document> documentCodec;
+
+            public MongoDb4DocumentObjectCodec(CodecRegistry registry) {
+                documentCodec = registry.get(Document.class);
+            }
+
+            @Override
+            public MongoDb4DocumentObject decode(BsonReader reader, DecoderContext decoderContext) {
+                Document document = documentCodec.decode(reader, decoderContext);
+                MongoDb4DocumentObject mongoDb4DocumentObject = new MongoDb4DocumentObject();
+                for (Map.Entry<String, Object> entry : document.entrySet()) {
+                    mongoDb4DocumentObject.set(entry.getKey(), entry.getValue());
+                }
+                return mongoDb4DocumentObject;
+            }
+
+            @Override
+            public void encode(BsonWriter writer, MongoDb4DocumentObject value, EncoderContext encoderContext) {
+                documentCodec.encode(writer, value.unwrap(), encoderContext);
+            }
+
+            @Override
+            public Class<MongoDb4DocumentObject> getEncoderClass() {
+                return MongoDb4DocumentObject.class;
+            }
+        }
     }
 }


### PR DESCRIPTION
问题：
当运行中，采用log4j2日志输入到mongo时候会出现编码问题。
```java
2023-04-19 08:33:31,447 replay-send-0 ERROR Unable to write to database [noSqlManager{ description=Mongo4, bufferSize=0, provider=MongoDb4Provider [connectionString=mongodb://arex:iLoveArex@mongodb:27017/arex_storage_db.logs, collectionSize=104857600, isCapped=true, mongoClient=com.mongodb.client.internal.MongoClientImpl@1b256636, mongoDatabase=com.mongodb.client.internal.MongoDatabaseImpl@7aab77f] }] for appender [Mongo4]. org.bson.codecs.configuration.CodecConfigurationException: Can't find a codec for class org.apache.logging.log4j.mongodb4.MongoDb4DocumentObject.
x-schedule  |    at com.arextest.schedule.sender.impl.HttpServletReplaySender.doInvoke(HttpServletReplaySender.java:169)
2023-04-19 16:33:31 arex-schedule  |    at com.arextest.schedule.sender.impl.HttpServletReplaySender.doSend(HttpServletReplaySender.java:101)
2023-04-19 16:33:31 arex-schedule  |    at com.arextest.schedule.sender.impl.HttpServletReplaySender.send(HttpServletReplaySender.java:129)
```

解决办法：
添加自定义编解码器
