### PR TITLE
feat: use eigen match

### DIFF
--- a/arex-storage-config/pom.xml
+++ b/arex-storage-config/pom.xml
@@ -45,7 +45,7 @@
   <parent>
     <artifactId>arex-storage-service</artifactId>
     <groupId>com.arextest</groupId>
-    <version>1.0.43</version>
+    <version>1.0.44</version>
   </parent>
 
   <properties>

--- a/arex-storage-model/pom.xml
+++ b/arex-storage-model/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>arex-storage-service</artifactId>
     <groupId>com.arextest</groupId>
-    <version>1.0.43</version>
+    <version>1.0.44</version>
   </parent>
 
   <profiles>

--- a/arex-storage-model/src/main/java/com/arextest/model/mock/AREXMocker.java
+++ b/arex-storage-model/src/main/java/com/arextest/model/mock/AREXMocker.java
@@ -1,6 +1,7 @@
 package com.arextest.model.mock;
 
 
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.FieldNameConstants;
@@ -40,6 +41,7 @@ public class AREXMocker implements Mocker {
    */
   private String recordVersion;
   private Integer continuousFailCount;
+  private Map<Integer, Long> eigenMap;
 
   public AREXMocker() {
 

--- a/arex-storage-model/src/main/java/com/arextest/model/mock/Mocker.java
+++ b/arex-storage-model/src/main/java/com/arextest/model/mock/Mocker.java
@@ -56,6 +56,15 @@ public interface Mocker {
 
   void setRecordVersion(String recordVersion);
 
+  Map<Integer, Long> getEigenMap();
+
+  /**
+   * Eigenvalues of mock data
+   * key: Hashcode for the key value of the JSON node
+   * value: The hash code of the value value value of the JSON node,
+   * The use of long type is to prevent memory overflow
+   */
+  void setEigenMap(Map<Integer, Long> eigenMap);
 
   @Getter
   @Setter

--- a/arex-storage-web-api/pom.xml
+++ b/arex-storage-web-api/pom.xml
@@ -24,6 +24,10 @@
       <artifactId>arex-storage-config</artifactId>
       <groupId>com.arextest</groupId>
     </dependency>
+    <dependency>
+      <artifactId>compare-sdk</artifactId>
+      <groupId>com.arextest</groupId>
+    </dependency>
     <!-- mongodb-driver-sync -->
     <dependency>
       <artifactId>mongodb-driver-sync</artifactId>
@@ -119,7 +123,7 @@
   <parent>
     <artifactId>arex-storage-service</artifactId>
     <groupId>com.arextest</groupId>
-    <version>1.0.43</version>
+    <version>1.0.44</version>
   </parent>
 
   <profiles>

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/mock/EigenProcessor.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/mock/EigenProcessor.java
@@ -1,0 +1,37 @@
+package com.arextest.storage.mock;
+
+import com.arextest.diff.model.eigen.EigenOptions;
+import com.arextest.diff.model.eigen.EigenResult;
+import com.arextest.diff.sdk.EigenSDK;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Calculates the eigen value of the body.
+ * created by xinyuan_wang on 2023/11/10
+ */
+public class EigenProcessor {
+
+  private static final EigenSDK eigenSDK = new EigenSDK();
+
+  public static Map<Integer, Long> calculateEigen(String body, String categoryName,
+      Collection<List<String>> exclusions,
+      Collection<String> nodeNames) {
+    EigenOptions options = EigenOptions.options();
+    options.putCategoryType(categoryName);
+    if (CollectionUtils.isNotEmpty(exclusions)) {
+      options.putExclusions(exclusions);
+    }
+    if (CollectionUtils.isNotEmpty(nodeNames)) {
+      options.putIgnoreNodes(nodeNames);
+    }
+    EigenResult eigenResult = eigenSDK.calculateEigen(body, options);
+    if (eigenResult == null) {
+      return null;
+    }
+    return eigenResult.getEigenMap();
+  }
+}

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/mock/MatchKeyBuilder.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/mock/MatchKeyBuilder.java
@@ -14,4 +14,11 @@ public interface MatchKeyBuilder {
   boolean isSupported(MockCategoryType categoryType);
 
   List<byte[]> build(Mocker instance);
+
+  /**
+   * Obtain the mocker that requires eigen value calculation
+   * @param instance
+   * @return
+   */
+  String getEigenBody(Mocker instance);
 }

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/mock/MatchKeyFactory.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/mock/MatchKeyFactory.java
@@ -39,4 +39,18 @@ public final class MatchKeyFactory {
     return matchKeyBuilder.build(instance);
   }
 
+  public String getEigenBody(@NotNull Mocker instance) {
+    MatchKeyBuilder matchKeyBuilder = find(instance.getCategoryType());
+    if (matchKeyBuilder == null) {
+      LOGGER.warn("Could not get eigen body for {}", instance);
+      return null;
+    }
+
+    if (instance.getTargetRequest() == null) {
+      LOGGER.warn("failed to get eigen body, recordId: {}, category: {}", instance.getRecordId(), instance.getCategoryType());
+      return null;
+    }
+    return matchKeyBuilder.getEigenBody(instance);
+  }
+
 }

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/mock/MockResultProvider.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/mock/MockResultProvider.java
@@ -3,6 +3,7 @@ package com.arextest.storage.mock;
 import com.arextest.model.mock.MockCategoryType;
 import com.arextest.model.mock.Mocker;
 import java.util.List;
+import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 /**
@@ -28,4 +29,11 @@ public interface MockResultProvider {
 
   <T extends Mocker> boolean removeRecordResult(MockCategoryType category, String recordId,
       Iterable<T> values);
+
+  /**
+   * Calculate the eigen values of the request body.
+   * @param item
+   * @return
+   */
+  void calculateEigen(@NotNull Mocker item);
 }

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/DefaultDependencyMatchKeyBuilderImpl.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/DefaultDependencyMatchKeyBuilderImpl.java
@@ -1,9 +1,11 @@
 package com.arextest.storage.mock.internal.matchkey.impl;
 
+import static com.arextest.diff.utils.JacksonHelperUtil.objectMapper;
 import com.arextest.model.mock.MockCategoryType;
 import com.arextest.model.mock.Mocker;
 import com.arextest.storage.cache.CacheKeyUtils;
 import com.arextest.storage.mock.MatchKeyBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringReader;
@@ -13,8 +15,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +26,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Order()
 final class DefaultDependencyMatchKeyBuilderImpl implements MatchKeyBuilder {
+
+  @Value("${arex.storage.use.eigen.match}")
+  private boolean useEigenMatch;
 
   @Override
   public boolean isSupported(MockCategoryType categoryType) {
@@ -37,7 +44,15 @@ final class DefaultDependencyMatchKeyBuilderImpl implements MatchKeyBuilder {
     }
     MessageDigest messageDigest = MessageDigestWriter.getMD5Digest();
     messageDigest.update(operationBytes);
-    StringReader stringReader = new StringReader(request.getBody());
+    String body = request.getBody();
+    if (useEigenMatch && MapUtils.isNotEmpty(instance.getEigenMap())) {
+      try {
+        body = objectMapper.writeValueAsString(instance.getEigenMap());
+      } catch (JsonProcessingException e) {
+        LOGGER.error("failed to get default dependency eigen map, recordId: {}", instance.getRecordId(), e);
+      }
+    }
+    StringReader stringReader = new StringReader(body);
     OutputStream output = new MessageDigestWriter(messageDigest);
     try {
       IOUtils.copy(stringReader, output, StandardCharsets.UTF_8);
@@ -46,5 +61,10 @@ final class DefaultDependencyMatchKeyBuilderImpl implements MatchKeyBuilder {
       LOGGER.error("Unknown dependency replay result match key build error:{}", e.getMessage(), e);
     }
     return Arrays.asList(messageDigest.digest(), operationBytes);
+  }
+
+  @Override
+  public String getEigenBody(Mocker instance) {
+    return instance.getTargetRequest().getBody();
   }
 }

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/DynamicClassMatchKeyBuilderImpl.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/DynamicClassMatchKeyBuilderImpl.java
@@ -1,19 +1,31 @@
 package com.arextest.storage.mock.internal.matchkey.impl;
 
+import static com.arextest.diff.utils.JacksonHelperUtil.objectMapper;
 import com.arextest.model.mock.MockCategoryType;
 import com.arextest.model.mock.Mocker;
+import com.arextest.model.mock.Mocker.Target;
 import com.arextest.storage.cache.CacheKeyUtils;
 import com.arextest.storage.mock.MatchKeyBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.security.MessageDigest;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Component
 @Order(10)
+@Slf4j
 final class DynamicClassMatchKeyBuilderImpl implements MatchKeyBuilder {
+
+  @Value("${arex.storage.use.eigen.match}")
+  private boolean useEigenMatch;
 
   @Override
   public boolean isSupported(MockCategoryType categoryType) {
@@ -22,10 +34,29 @@ final class DynamicClassMatchKeyBuilderImpl implements MatchKeyBuilder {
 
   @Override
   public List<byte[]> build(Mocker instance) {
-    MessageDigest messageDigest = MessageDigestWriter.getMD5Digest();
     byte[] operationNameBytes = CacheKeyUtils.toUtf8Bytes(instance.getOperationName());
+    Target targetRequest = instance.getTargetRequest();
+    if (targetRequest == null || StringUtils.isEmpty(targetRequest.getBody())) {
+      return Collections.singletonList(operationNameBytes);
+    }
+
+    MessageDigest messageDigest = MessageDigestWriter.getMD5Digest();
     messageDigest.update(operationNameBytes);
-    messageDigest.update(CacheKeyUtils.toUtf8Bytes(instance.getTargetRequest().getBody()));
+
+    String body = targetRequest.getBody();
+    if (useEigenMatch && MapUtils.isNotEmpty(instance.getEigenMap())) {
+      try {
+        body = objectMapper.writeValueAsString(instance.getEigenMap());
+      } catch (JsonProcessingException e) {
+        LOGGER.error("failed to get dynamic class eigen map, recordId: {}", instance.getRecordId(), e);
+      }
+    }
+    messageDigest.update(CacheKeyUtils.toUtf8Bytes(body));
     return Arrays.asList(messageDigest.digest(), operationNameBytes);
+  }
+
+  @Override
+  public String getEigenBody(Mocker instance) {
+    return instance.getTargetRequest().getBody();
   }
 }

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/EntryPointMatchKeyBuilderImpl.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/EntryPointMatchKeyBuilderImpl.java
@@ -21,4 +21,9 @@ final class EntryPointMatchKeyBuilderImpl implements MatchKeyBuilder {
     byte[] operationBytes = CacheKeyUtils.toUtf8Bytes(instance.getOperationName());
     return Collections.singletonList(operationBytes);
   }
+
+  @Override
+  public String getEigenBody(Mocker instance) {
+    return instance.getTargetRequest().getBody();
+  }
 }

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/QMessageProduceMatchKeyBuilderImpl.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/QMessageProduceMatchKeyBuilderImpl.java
@@ -1,9 +1,11 @@
 package com.arextest.storage.mock.internal.matchkey.impl;
 
+import static com.arextest.diff.utils.JacksonHelperUtil.objectMapper;
 import com.arextest.model.mock.MockCategoryType;
 import com.arextest.model.mock.Mocker;
 import com.arextest.storage.cache.CacheKeyUtils;
 import com.arextest.storage.mock.MatchKeyBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringReader;
@@ -14,8 +16,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +27,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Order(20)
 final class QMessageProduceMatchKeyBuilderImpl implements MatchKeyBuilder {
+
+  @Value("${arex.storage.use.eigen.match}")
+  private boolean useEigenMatch;
 
   @Override
   public boolean isSupported(MockCategoryType categoryType) {
@@ -38,7 +45,15 @@ final class QMessageProduceMatchKeyBuilderImpl implements MatchKeyBuilder {
     }
     MessageDigest messageDigest = MessageDigestWriter.getMD5Digest();
     messageDigest.update(operationBytes);
-    StringReader stringReader = new StringReader(request.getBody());
+    String body = request.getBody();
+    if (useEigenMatch && MapUtils.isNotEmpty(instance.getEigenMap())) {
+      try {
+        body = objectMapper.writeValueAsString(instance.getEigenMap());
+      } catch (JsonProcessingException e) {
+        LOGGER.error("failed to get http client eigen map, recordId: {}", instance.getRecordId(), e);
+      }
+    }
+    StringReader stringReader = new StringReader(body);
     OutputStream output = new MessageDigestWriter(messageDigest);
     try {
       IOUtils.copy(stringReader, output, StandardCharsets.UTF_8);
@@ -47,5 +62,10 @@ final class QMessageProduceMatchKeyBuilderImpl implements MatchKeyBuilder {
       LOGGER.error("QMessageProduce replay result match key build error:{}", e.getMessage(), e);
     }
     return Arrays.asList(messageDigest.digest(), operationBytes);
+  }
+
+  @Override
+  public String getEigenBody(Mocker instance) {
+    return instance.getTargetRequest().getBody();
   }
 }

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/RedisMatchKeyBuilderImpl.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/mock/internal/matchkey/impl/RedisMatchKeyBuilderImpl.java
@@ -5,18 +5,33 @@ import com.arextest.model.mock.MockCategoryType;
 import com.arextest.model.mock.Mocker;
 import com.arextest.storage.cache.CacheKeyUtils;
 import com.arextest.storage.mock.MatchKeyBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Component
 @Order(25)
+@Slf4j
 final class RedisMatchKeyBuilderImpl implements MatchKeyBuilder {
+
+  private final ObjectMapper objectMapper;
+  private static final String BODY = "body";
+  @Value("${arex.storage.use.eigen.match}")
+  private boolean useEigenMatch;
+  RedisMatchKeyBuilderImpl(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
 
   @Override
   public boolean isSupported(MockCategoryType categoryType) {
@@ -32,10 +47,36 @@ final class RedisMatchKeyBuilderImpl implements MatchKeyBuilder {
     }
     MessageDigest messageDigest = MessageDigestWriter.getMD5Digest();
     messageDigest.update(operationBytes);
-    byte[] redisKeyBytes = CacheKeyUtils.toUtf8Bytes(request.getBody());
-    messageDigest.update(redisKeyBytes);
-    messageDigest.update(
-        CacheKeyUtils.toUtf8Bytes(request.attributeAsString(MockAttributeNames.CLUSTER_NAME)));
+    if (useEigenMatch && MapUtils.isNotEmpty(instance.getEigenMap())) {
+      String eigenBody = request.getBody();
+      try {
+        eigenBody = objectMapper.writeValueAsString(instance.getEigenMap());
+      } catch (JsonProcessingException e) {
+        LOGGER.error("failed to get http client eigen map, recordId: {}", instance.getRecordId(), e);
+      }
+      messageDigest.update(CacheKeyUtils.toUtf8Bytes(eigenBody));
+    } else {
+      byte[] redisKeyBytes = CacheKeyUtils.toUtf8Bytes(request.getBody());
+      messageDigest.update(redisKeyBytes);
+      messageDigest.update(
+          CacheKeyUtils.toUtf8Bytes(request.attributeAsString(MockAttributeNames.CLUSTER_NAME)));
+    }
     return Arrays.asList(messageDigest.digest(), operationBytes);
+  }
+
+  /**
+   * For the type of redis, it is necessary to concatenate request body and clusterName to calculate the feature values
+   * @param instance
+   * @return
+   */
+  @Override
+  public String getEigenBody(Mocker instance) {
+    Object clusterName = instance.getTargetRequest().getAttribute(MockAttributeNames.CLUSTER_NAME);
+    ObjectNode objectNode = objectMapper.createObjectNode();
+    objectNode.put(BODY, instance.getTargetRequest().getBody());
+    if (clusterName != null) {
+      objectNode.put(MockAttributeNames.CLUSTER_NAME, clusterName.toString());
+    }
+    return objectNode.toString();
   }
 }

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/AREXMockerCodecProvider.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/AREXMockerCodecProvider.java
@@ -22,8 +22,10 @@ final class AREXMockerCodecProvider implements CodecProvider {
 
   private final static String TARGET_REQUEST_NAME = "targetRequest";
   private final static String TARGET_RESPONSE_NAME = "targetResponse";
+  private final static String EIGEN_MAP_NAME = "eigenMap";
   private static final String CATEGORY_TYPE = "categoryType";
   private final Codec<?> millisecondsDateTimeCodec = new MillisecondsDateTimeCodecImpl();
+  private final Codec<?> eigenMapCodec = new EigenMapCodecImpl();
   private volatile Codec<AREXMocker> arexMockerCodec;
   private Codec<?> targetCodec;
 
@@ -76,6 +78,9 @@ final class AREXMockerCodecProvider implements CodecProvider {
     }
     if (TARGET_RESPONSE_NAME.equals(propertyModelBuilder.getName())) {
       return targetCodec;
+    }
+    if (EIGEN_MAP_NAME.equals(propertyModelBuilder.getName())) {
+      return eigenMapCodec;
     }
     if (AREXMockerMongoRepositoryProvider.CREATE_TIME_COLUMN_NAME.equals(
         propertyModelBuilder.getName())

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/AREXMockerMongoRepositoryProvider.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/AREXMockerMongoRepositoryProvider.java
@@ -63,6 +63,7 @@ public class AREXMockerMongoRepositoryProvider implements RepositoryProvider<ARE
   private static final String PROJECT_OP = "$project";
   private static final String AGENT_RECORD_VERSION_COLUMN_NAME = "recordVersion";
   private static final String TARGET_RESPONSE_COLUMN_NAME = "targetResponse";
+  private static final String EIGEN_MAP_COLUMN_NAME = "eigenMap";
   private final static Bson CREATE_TIME_ASCENDING_SORT = Sorts.ascending(CREATE_TIME_COLUMN_NAME);
   private final static Bson CREATE_TIME_DESCENDING_SORT = Sorts.descending(CREATE_TIME_COLUMN_NAME);
   private static final int DEFAULT_MIN_LIMIT_SIZE = 1;
@@ -153,7 +154,7 @@ public class AREXMockerMongoRepositoryProvider implements RepositoryProvider<ARE
 
     Iterable<AREXMocker> iterable = collectionSource
         .find(Filters.and(bsons))
-        .projection(Projections.exclude(TARGET_RESPONSE_COLUMN_NAME))
+        .projection(Projections.exclude(TARGET_RESPONSE_COLUMN_NAME, EIGEN_MAP_COLUMN_NAME))
         .sort(toSupportSortingOptions(pagedRequestType.getSortingOptions()))
         .skip(pageIndex == null ? 0 : pagedRequestType.getPageSize() * (pageIndex - 1))
         .limit(Math.min(pagedRequestType.getPageSize(), DEFAULT_MAX_LIMIT_SIZE));

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/EigenMapCodecImpl.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/EigenMapCodecImpl.java
@@ -1,0 +1,57 @@
+package com.arextest.storage.repository.impl.mongo;
+
+import static com.arextest.diff.utils.JacksonHelperUtil.objectMapper;
+import com.arextest.common.utils.SerializationUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+
+/**
+ * Convert eigenMap to encrypted string for storage
+ *
+ * @author xinyuan_wang
+ * @since 2023/11/28
+ */
+@Slf4j
+final class EigenMapCodecImpl implements Codec<Map> {
+
+  @Override
+  public Map decode(BsonReader reader, DecoderContext decoderContext) {
+    String encodeWithEncryptString = reader.readString();
+    String eigenMapStr = SerializationUtils.useZstdDeserialize(encodeWithEncryptString, String.class);
+    if (StringUtils.isEmpty(eigenMapStr)) {
+      LOGGER.info("decode eigen map is null. encodeWithEncryptString: {}", encodeWithEncryptString);
+    }
+    try {
+      return objectMapper.readValue(eigenMapStr, new TypeReference<Map<Integer, Long>>() {});
+    } catch (JsonProcessingException e) {
+      LOGGER.error("failed to decode eigen map, {}, eigenMapStr: {}", e.getMessage(), eigenMapStr, e);
+      return null;
+    }
+  }
+
+  @Override
+  public void encode(BsonWriter writer, Map value, EncoderContext encoderContext) {
+    String string = null;
+    try {
+      string = objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException e) {
+      LOGGER.error("failed to encode eigen map. {}", e.getMessage(), e);
+      return;
+    }
+    String base64Result = SerializationUtils.useZstdSerializeToBase64(string);
+    writer.writeString(base64Result);
+  }
+
+  @Override
+  public Class<Map> getEncoderClass() {
+    return Map.class;
+  }
+}

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/service/AgentWorkingService.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/service/AgentWorkingService.java
@@ -68,6 +68,7 @@ public class AgentWorkingService {
       return false;
     }
 
+    mockResultProvider.calculateEigen(item);
     MockerSaveHandler<T> handler = mockerHandlerFactory.getHandler(item.getCategoryType());
     if (handler != null) {
       handler.handle(item);

--- a/arex-storage-web-api/src/main/resources/application.yaml
+++ b/arex-storage-web-api/src/main/resources/application.yaml
@@ -40,5 +40,8 @@ arex:
         similarity:
           strategy:
             appIds:
+    use:
+      eigen:
+        match: false
 pom:
   version: ${project.version}

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,11 @@
         <version>0.0.1</version>
       </dependency>
       <dependency>
+        <artifactId>compare-sdk</artifactId>
+        <groupId>com.arextest</groupId>
+        <version>0.2.0</version>
+      </dependency>
+      <dependency>
         <artifactId>jsr250-api</artifactId>
         <groupId>javax.annotation</groupId>
         <version>1.0</version>
@@ -403,5 +408,5 @@
   <url>https://github.com/arextest/arex-storage</url>
 
 
-  <version>1.0.43</version>
+  <version>1.0.44</version>
 </project>


### PR DESCRIPTION
1. When record data is saved, the eigen values are stored in attributes
2. When cache is loaded, need to be compatible with data that does not have saved eigenvalues
3. In the scenario of multiple calls, the data with the highest similarity is selected based on the number of overlapping nodes in the recorded and played packets