### PR TITLE
feat: Solve the problem of missed data deletion in coverage handle

### DIFF
--- a/arex-storage-web-api/src/main/java/com/arextest/storage/beans/StorageAutoConfiguration.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/beans/StorageAutoConfiguration.java
@@ -29,7 +29,7 @@ import com.arextest.storage.repository.impl.mongo.converters.ArexEigenCompressio
 import com.arextest.storage.repository.impl.mongo.converters.ArexMockerCompressionConverter;
 import com.arextest.storage.serialization.ZstdJacksonSerializer;
 import com.arextest.storage.service.AgentWorkingService;
-import com.arextest.storage.service.InvalidIncompleteRecordService;
+import com.arextest.storage.service.InvalidRecordService;
 import com.arextest.storage.service.MockSourceEditionService;
 import com.arextest.storage.service.PrepareMockResultService;
 import com.arextest.storage.service.QueryConfigService;
@@ -210,11 +210,11 @@ public class StorageAutoConfiguration {
       ZstdJacksonSerializer zstdJacksonSerializer,
       PrepareMockResultService prepareMockResultService,
       List<AgentWorkingListener> agentWorkingListeners,
-      InvalidIncompleteRecordService invalidIncompleteRecordService,
+      InvalidRecordService invalidRecordService,
       ScheduleReplayingService scheduleReplayingService) {
     AgentWorkingService workingService = new AgentWorkingService(mockResultProvider,
         repositoryProviderFactory, agentWorkingListeners,
-        invalidIncompleteRecordService, scheduleReplayingService);
+        invalidRecordService, scheduleReplayingService);
     workingService.setPrepareMockResultService(prepareMockResultService);
     workingService.setZstdJacksonSerializer(zstdJacksonSerializer);
     workingService.setRecordEnvType(properties.getRecordEnv());
@@ -240,9 +240,9 @@ public class StorageAutoConfiguration {
   public ScheduleReplayQueryController scheduleReplayQueryController(
       ScheduleReplayingService scheduleReplayingService,
       PrepareMockResultService prepareMockResultService,
-      InvalidIncompleteRecordService invalidIncompleteRecordService) {
+      InvalidRecordService invalidRecordService) {
     return new ScheduleReplayQueryController(scheduleReplayingService, prepareMockResultService,
-        invalidIncompleteRecordService);
+        invalidRecordService);
   }
 
   @Bean

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/AREXMockerMongoRepositoryProvider.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/repository/impl/mongo/AREXMockerMongoRepositoryProvider.java
@@ -115,7 +115,7 @@ public class AREXMockerMongoRepositoryProvider implements RepositoryProvider<ARE
       query.fields().include(fieldNames);
     }
 
-    Iterable<AREXMocker> iterable = mongoTemplate.find(new Query(criteria),
+    Iterable<AREXMocker> iterable = mongoTemplate.find(query,
         AREXMocker.class, getCollectionName(category));
     iterable.forEach(this::addUseMocker);
     return new AttachmentCategoryIterable(category, iterable);

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/service/AgentWorkingService.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/service/AgentWorkingService.java
@@ -13,16 +13,12 @@ import com.arextest.storage.repository.RepositoryProviderFactory;
 import com.arextest.storage.repository.RepositoryReader;
 import com.arextest.storage.serialization.ZstdJacksonSerializer;
 import com.arextest.storage.service.listener.AgentWorkingListener;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -38,7 +34,7 @@ public class AgentWorkingService {
   private final MockResultProvider mockResultProvider;
   private final RepositoryProviderFactory repositoryProviderFactory;
   private final List<AgentWorkingListener> agentWorkingListeners;
-  private final InvalidIncompleteRecordService invalidIncompleteRecordService;
+  private final InvalidRecordService invalidRecordService;
   private final ScheduleReplayingService scheduleReplayingService;
   @Setter
   private ZstdJacksonSerializer zstdJacksonSerializer;
@@ -50,12 +46,12 @@ public class AgentWorkingService {
   public AgentWorkingService(MockResultProvider mockResultProvider,
       RepositoryProviderFactory repositoryProviderFactory,
       List<AgentWorkingListener> agentWorkingListeners,
-      InvalidIncompleteRecordService invalidIncompleteRecordService,
+      InvalidRecordService invalidRecordService,
       ScheduleReplayingService scheduleReplayingService) {
     this.mockResultProvider = mockResultProvider;
     this.repositoryProviderFactory = repositoryProviderFactory;
     this.agentWorkingListeners = agentWorkingListeners;
-    this.invalidIncompleteRecordService = invalidIncompleteRecordService;
+    this.invalidRecordService = invalidRecordService;
     this.scheduleReplayingService = scheduleReplayingService;
   }
 
@@ -72,7 +68,6 @@ public class AgentWorkingService {
       item.setRecordEnvironment(recordEnvType.getCodeValue());
     }
     if (!this.dispatchRecordSavingEvent(item)) {
-      LOGGER.warn("dispatch record saving event failed, skip save record data");
       return false;
     }
 
@@ -190,6 +185,6 @@ public class AgentWorkingService {
   }
 
   public void invalidIncompleteRecord(InvalidIncompleteRecordRequest request) {
-    invalidIncompleteRecordService.invalidIncompleteRecord(request.getRecordId(), request.getReplayId());
+    invalidRecordService.invalidIncompleteRecord(request.getRecordId(), request.getReplayId());
   }
 }

--- a/arex-storage-web-api/src/main/java/com/arextest/storage/web/controller/ScheduleReplayQueryController.java
+++ b/arex-storage-web-api/src/main/java/com/arextest/storage/web/controller/ScheduleReplayQueryController.java
@@ -17,14 +17,13 @@ import com.arextest.model.replay.holder.ListResultHolder;
 import com.arextest.model.response.Response;
 import com.arextest.storage.mock.MockerPostProcessor;
 import com.arextest.storage.repository.ProviderNames;
-import com.arextest.storage.service.InvalidIncompleteRecordService;
+import com.arextest.storage.service.InvalidRecordService;
 import com.arextest.storage.service.PrepareMockResultService;
 import com.arextest.storage.service.ScheduleReplayingService;
 import com.arextest.storage.trace.MDCTracer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -37,8 +36,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 /**
  * this class defined all api list for scheduler replaying
@@ -55,7 +52,7 @@ public class ScheduleReplayQueryController {
 
   private final PrepareMockResultService prepareMockResultService;
 
-  private final InvalidIncompleteRecordService invalidIncompleteRecordService;
+  private final InvalidRecordService invalidRecordService;
 
   /**
    * fetch the replay result for compare
@@ -85,7 +82,7 @@ public class ScheduleReplayQueryController {
           scheduleReplayingService.queryReplayResult(recordId, replayResultId);
       QueryReplayResultResponseType responseType = new QueryReplayResultResponseType();
       responseType.setResultHolderList(resultHolderList);
-      responseType.setInvalidResult(invalidIncompleteRecordService.isInvalidReplayIncompleteCase(replayResultId));
+      responseType.setInvalidResult(invalidRecordService.isInvalidReplayIncompleteCase(replayResultId));
       return ResponseUtils.successResponse(responseType);
     } catch (Throwable throwable) {
       LOGGER.error("replayResult error:{} ,recordId:{} ,replayResultId:{}",

--- a/pom.xml
+++ b/pom.xml
@@ -427,7 +427,7 @@
   </profiles>
 
   <properties>
-    <revision>1.2.8</revision>
+    <revision>1.2.9</revision>
     <commons-lang3.version>3.3.2</commons-lang3.version>
     <java.version>1.8</java.version>
 
@@ -449,7 +449,7 @@
     </sonar.exclusions>
     <!-- Users could specify this property as true to skip the deploy process -->
     <spring.boot.version>2.7.18</spring.boot.version>
-    <arex-common.version>0.1.30</arex-common.version>
+    <arex-common.version>0.2.0</arex-common.version>
     <reddison.version>3.20.1</reddison.version>
   </properties>
   <scm>


### PR DESCRIPTION
1. The case that triggers the coverage deletion operation, and the remaining dependencies are not saved.
2. Change the batchSave api to batchSaveMockers